### PR TITLE
Support Rancher development image and tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ kubeconfig-e2e.yml
 
 # Ignore the downloaded CA certificate for tls-rancher
 ca-additional.pem
+
+.terraform.lock.hcl

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+terraform state rm helm_release.cert-manager
+terraform state rm helm_release.rancher
+terraform state rm kubernetes_namespace.cattle-system
+terraform state rm kubernetes_namespace.cattle-csp-billing-adapter-system
+terraform destroy

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -93,6 +93,18 @@ resource "helm_release" "rancher"{
     name = "installCRDs"
     value = "true"
   }
+  set {
+    name = "rancherImage"
+    value = var.rancher_image_repo
+  }
+  set {
+    name = "rancherImageTag"
+    value = var.rancher_image_tag == "" ? var.rancher_version : var.rancher_image_tag
+  }
+  set {
+    name = "rancherImagePullPolicy"
+    value = var.rancher_image_pull_policy
+  }
   values = [yamlencode({
   extraEnv: [
     {

--- a/terraform/terraform.template.tfvars
+++ b/terraform/terraform.template.tfvars
@@ -36,3 +36,12 @@ eks_version = "1.24"
 
 # Admin password to use for Rancher server bootstrap, min. 12 characters
 rancher_server_admin_password = "r@ncher1234!"
+
+# Rancher image repository
+rancher_image_repo = "rancher/rancher"
+
+# Rancher image tag - optional. If not specified, it would be the same as the Rancher chart version.
+rancher_image_tag = ""
+
+# Rancher image pull policy
+rancher_image_pull_policy = "IfNotPresent"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,3 +105,21 @@ variable "namespace" {
   description = "Namespace for the csp-rancher-usage-operator and csp-billing-adapter install"
   default="cattle-csp-billing-adapter-system"
 }
+
+variable "rancher_image_repo" {
+  type = string
+  description = "Rancher image repository"
+  default="rancher/rancher"
+}
+
+variable "rancher_image_tag" {
+  type = string
+  description = "Rancher image tag - optional. If not specified, it would be the same as the Rancher chart version."
+  default = ""
+}
+
+variable "rancher_image_pull_policy" {
+  type = string
+  description = "Rancher image pull policy"
+  default="IfNotPresent"
+}


### PR DESCRIPTION
Enable user to override the production Rancher image with a development one, by specifying the alternative location for the Rancher image, along with the new image tag and pull policy.